### PR TITLE
fix luacheck warning

### DIFF
--- a/strong.lua
+++ b/strong.lua
@@ -23,6 +23,7 @@ end
 -- METATABLE --
 
 local mt = getmetatable("")
+local string = mt.__index
 
 -- OPERATORS --
 


### PR DESCRIPTION
luacheck doesn't like modifying global variable "string":

```
strong.lua:66:10: mutating read-only global variable string
strong.lua:74:10: mutating read-only global variable string
...
```
